### PR TITLE
Tiles enhancements

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -215,7 +215,6 @@
     grid-area: posters;
     display: flex;
     justify-content: flex-end;
-    padding: 0 0 0 5px;
 
     .inline {
       align-self: center;

--- a/common/common.scss
+++ b/common/common.scss
@@ -178,7 +178,6 @@
     grid-area: tfooter;
     vertical-align: middle;
     display: grid;
-    padding-top: 10px;
     z-index: 10;
     grid-template-columns: 9fr 12fr 10fr;
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -20,6 +20,10 @@
     border-top: none;
   }
 
+  .topic-list-item, tr {
+    border: none;
+  }
+
   .tiles-grid-item-width2 {
     box-sizing: border-box;
     cursor: pointer;

--- a/common/common.scss
+++ b/common/common.scss
@@ -185,7 +185,8 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 150px 1fr 105px;
+    grid-template-columns: 4fr 6fr 5fr;
+
     grid-template-rows: 1;
     grid-template-areas:
       "meta posters actions";
@@ -194,16 +195,26 @@
   .topic-meta {
     display: flex;
 
-    .inline {
+    .container {
       align-self: center;
-    }
 
-    .topic-views {
-      color: var(--primary-medium);
-    }
+      .top-line {
+        display: inline;
 
-    .topic-replies span {
-      padding-left: 3px;
+        .topic-views {
+          color: var(--primary-medium);
+        }
+        .topic-replies {
+          padding-left: 3px;
+        }
+      }
+      .bottom-line {
+        align-self: start;
+
+        .topic-timing {
+          vertical-align: top;
+        }
+      }
     }
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -15,7 +15,7 @@
     }
     display: grid;
     gap: 6px;
-    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
     grid-auto-rows: 4px;
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -14,7 +14,7 @@
       display: none;
     }
     display: grid;
-    gap: 6px;
+    gap: 4px;
     grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
     grid-auto-rows: 4px;
     border-top: none;
@@ -177,7 +177,6 @@
     grid-area: tfooter;
     vertical-align: middle;
     display: grid;
-    padding-top: 0.33em;
     z-index: 10;
     grid-template-columns: 9fr 12fr 10fr;
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -139,7 +139,6 @@
 
   .topic-category {
     grid-area: category;
-    padding: 0 0 4px 0;
     display: inline-block;
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -213,6 +213,7 @@
 
   .topic-meta {
     grid-area: meta;
+    display: flex;
 
     .inline {
       align-self: center;

--- a/common/common.scss
+++ b/common/common.scss
@@ -130,7 +130,6 @@
     }
 
     a.topic-featured-link {
-      display: block;
       padding-left: 0;
       padding-top: 3px;
     }

--- a/common/common.scss
+++ b/common/common.scss
@@ -142,9 +142,11 @@
     display: inline-block;
   }
 
-  .thumbnail {
-    .no-thumbnail {
-      display: none;
+  .topic-tags {
+    grid-area: tags;
+
+    .discourse-tags {
+      display: inline-block;
     }
   }
 
@@ -169,14 +171,6 @@
     -moz-hyphens: auto;
     -webkit-hyphens: auto;
     hyphens: auto;
-  }
-
-  .topic-tags {
-    grid-area: tags;
-
-    .discourse-tags {
-      display: inline-block;
-    }
   }
 
   .topic-footer {

--- a/common/common.scss
+++ b/common/common.scss
@@ -17,6 +17,7 @@
     gap: 6px;
     grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
     grid-auto-rows: 4px;
+    border-top: none;
   }
 
   .tiles-grid-item-width2 {

--- a/common/common.scss
+++ b/common/common.scss
@@ -88,7 +88,7 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 6fr 4fr 5fr;
+    grid-template-columns: 6fr 4fr 4fr;
     grid-template-rows: 1;
     grid-template-areas:
       "meta posters actions";

--- a/common/common.scss
+++ b/common/common.scss
@@ -197,6 +197,9 @@
 
     .container {
       align-self: center;
+      a {
+        display: inline-block;
+      }
 
       .top-line {
         display: inline;

--- a/common/common.scss
+++ b/common/common.scss
@@ -74,13 +74,24 @@
     display: grid;
     padding: 10px 10px 10px 10px;
     z-index: 10;
-    grid-template-columns: 1 1 1 1 auto;
-    grid-template-rows: auto auto auto auto;
+    grid-template-columns: auto auto auto;
+    grid-template-rows: auto auto auto;
     grid-template-areas:
-      "theader theader theader theader theader"
-      "excerpt excerpt excerpt excerpt excerpt"
-      "tags tags tags tags tags"
-      "meta meta meta meta actions";
+      "theader theader theader"
+      "excerpt excerpt excerpt"
+      "tfooter tfooter tfooter";
+  }
+
+  .topic-footer {
+    grid-area: tfooter;
+    vertical-align: middle;
+    display: grid;
+    padding-top: 10px;
+    z-index: 10;
+    grid-template-columns: 6fr 5fr 5fr;
+    grid-template-rows: 1;
+    grid-template-areas:
+      "meta posters actions";
   }
 
   .tiles-grid-item:hover {
@@ -94,11 +105,11 @@
   .topic-header-grid {
     grid-area: theader;
     display: grid;
-    grid-template-columns: auto auto;
-    grid-template-rows: auto auto;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
     grid-template-areas:
-      "title posters"
-      "category posters";
+      "title"
+      "category";
   }
 
   .show-more.has-topics {
@@ -159,6 +170,7 @@
   .topic-category {
     grid-area: category;
     padding: 0 0 4px 0;
+    display: inline-block;
   }
 
   .thumbnail {
@@ -273,7 +285,6 @@ html:not(.tile-style) {
 
   .topic-actions {
     display: block;
-    margin-top: 5px;
     .like-count:empty {
       margin-right: 0;
     }
@@ -298,7 +309,6 @@ img.thumbnail {
   color: var(--primary-medium);
   font-size: 13px;
   display: inline-block;
-  vertical-align: bottom;
   margin-right: 7px;
 
   .vote-count {

--- a/common/common.scss
+++ b/common/common.scss
@@ -317,7 +317,7 @@ img.thumbnail {
   color: var(--primary-medium);
   font-size: 13px;
   display: inline-block;
-  margin-right: 7px;
+  padding-right: 5px;
 
   .vote-count {
     height: initial;
@@ -330,11 +330,6 @@ img.thumbnail {
 //   float: left;
 //   padding-right: 3px;
 //   margin-top: 5px;
-// }
-
-// .topic-actions .list-vote-count {
-//   float: none;
-//   margin-top: 0;
 // }
 
 button.list-button {

--- a/common/common.scss
+++ b/common/common.scss
@@ -82,18 +82,6 @@
       "tfooter tfooter tfooter";
   }
 
-  .topic-footer {
-    grid-area: tfooter;
-    vertical-align: middle;
-    display: grid;
-    padding-top: 10px;
-    z-index: 10;
-    grid-template-columns: 7fr 4fr 5fr;
-    grid-template-rows: 1;
-    grid-template-areas:
-      "meta posters actions";
-  }
-
   .tiles-grid-item:hover {
     background-color: var(--blend-primary-secondary-5);
 
@@ -144,26 +132,6 @@
     color: var(--primary-medium);
   }
 
-  .topic-users {
-    grid-area: posters;
-    display: flex;
-    justify-content: flex-end;
-    padding: 0 0 0 5px;
-
-    .inline {
-      align-self: center;
-      text-align: right;
-      color: var(--primary-med-or-secondary-med);
-
-      .avatar {
-        padding: 0 0 0 0px;
-        margin-right: -2px;
-        width: 22px;
-        height: 22px;
-      }
-    }
-  }
-
   .topic-statuses {
     float: right;
   }
@@ -211,8 +179,19 @@
     }
   }
 
+  .topic-footer {
+    grid-area: tfooter;
+    vertical-align: middle;
+    display: grid;
+    padding-top: 10px;
+    z-index: 10;
+    grid-template-columns: 150px 1fr 110px;
+    grid-template-rows: 1;
+    grid-template-areas:
+      "meta posters actions";
+  }
+
   .topic-meta {
-    grid-area: meta;
     display: flex;
 
     .inline {
@@ -230,6 +209,41 @@
 
   .topic-poster-names a {
     font-size: 0.9em;
+  }
+
+  .topic-users {
+    grid-area: posters;
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 0 0 5px;
+
+    .inline {
+      align-self: center;
+      text-align: right;
+      color: var(--primary-med-or-secondary-med);
+
+      .avatar {
+        padding: 0 0 0 0px;
+        margin-right: -2px;
+        width: 22px;
+        height: 22px;
+      }
+    }
+  }
+
+  .topic-actions {
+    grid-area: actions;
+    display: flex;
+    justify-content: flex-end;
+
+    .inline {
+      align-self: center;
+      text-align: right;
+    }
+  }
+
+  .middot:after {
+    content: "\00B7";
   }
 
   div.sub,
@@ -252,24 +266,7 @@
     padding-top: 3px;
   }
 
-  .topic-meta {
-    float: left;
-  }
 
-  .topic-actions {
-    grid-area: actions;
-    display: flex;
-    justify-content: flex-end;
-
-    .inline {
-      align-self: center;
-      text-align: right;
-    }
-  }
-
-  .middot:after {
-    content: "\00B7";
-  }
 }
 
 //styling excluding tiles

--- a/common/common.scss
+++ b/common/common.scss
@@ -363,6 +363,12 @@ button.list-button {
     box-shadow: none;
   }
 
+  &.topic-share:hover {
+    .d-icon-link {
+      color: var(--tertiary);
+    }
+  }
+
   &.bookmarked,
   &.topic-bookmark:hover {
     i.fa-bookmark,

--- a/common/common.scss
+++ b/common/common.scss
@@ -88,7 +88,7 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 6fr 4fr 4fr;
+    grid-template-columns: 7fr 4fr 5fr;
     grid-template-rows: 1;
     grid-template-areas:
       "meta posters actions";

--- a/common/common.scss
+++ b/common/common.scss
@@ -15,7 +15,7 @@
     }
     display: grid;
     gap: 6px;
-    grid-template-columns: repeat(auto-fit, minmax(358px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
     grid-auto-rows: 4px;
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -15,7 +15,7 @@
     }
     display: grid;
     gap: 6px;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(356px, 1fr));
     grid-auto-rows: 4px;
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -88,7 +88,7 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 6fr 5fr 5fr;
+    grid-template-columns: 6fr 4fr 5fr;
     grid-template-rows: 1;
     grid-template-areas:
       "meta posters actions";
@@ -153,6 +153,7 @@
       float: right;
       line-height: 24px;
       text-align: right;
+      color: var(--primary-med-or-secondary-med);
 
       .avatar {
         padding: 0 0 0 0px;

--- a/common/common.scss
+++ b/common/common.scss
@@ -88,7 +88,7 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 6fr 4fr 5fr;
+    grid-template-columns: 6fr 4fr 6fr;
     grid-template-rows: 1;
     grid-template-areas:
       "meta posters actions";
@@ -146,11 +146,13 @@
 
   .topic-users {
     grid-area: posters;
-    padding: 0 0 5px 5px;
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 0 0 5px;
 
     .inline {
-      float: right;
-      line-height: 24px;
+      vertical-align: middle;
+      align-self: center;
       text-align: right;
       color: var(--primary-med-or-secondary-med);
 
@@ -212,6 +214,10 @@
 
   .topic-meta {
     grid-area: meta;
+
+    .inline {
+      align-self: center;
+    }
 
     .topic-views {
       color: var(--primary-medium);
@@ -335,6 +341,7 @@ button.list-button {
   border: none;
   padding: 2px 4px;
   overflow: hidden;
+  color: var(--primary-medium);
 
   &:first-of-type {
     padding-left: 0;

--- a/common/common.scss
+++ b/common/common.scss
@@ -15,7 +15,7 @@
     }
     display: grid;
     gap: 6px;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
     grid-auto-rows: 4px;
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -185,7 +185,7 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 150px 1fr 110px;
+    grid-template-columns: 150px 1fr 105px;
     grid-template-rows: 1;
     grid-template-areas:
       "meta posters actions";

--- a/common/common.scss
+++ b/common/common.scss
@@ -180,7 +180,7 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 4fr 6fr 5fr;
+    grid-template-columns: 9fr 12fr 10fr;
 
     grid-template-rows: 1;
     grid-template-areas:

--- a/common/common.scss
+++ b/common/common.scss
@@ -88,7 +88,7 @@
     display: grid;
     padding-top: 10px;
     z-index: 10;
-    grid-template-columns: 6fr 4fr 6fr;
+    grid-template-columns: 6fr 4fr 5fr;
     grid-template-rows: 1;
     grid-template-areas:
       "meta posters actions";
@@ -272,7 +272,7 @@
 }
 
 //styling excluding tiles
-html:not(.tile-style) {
+html:not(>tile-style) {
   .topic-list .link-bottom-line {
     display: block;
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -178,6 +178,7 @@
     grid-area: tfooter;
     vertical-align: middle;
     display: grid;
+    padding-top: 0.33em;
     z-index: 10;
     grid-template-columns: 9fr 12fr 10fr;
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -151,7 +151,6 @@
     padding: 0 0 0 5px;
 
     .inline {
-      vertical-align: middle;
       align-self: center;
       text-align: right;
       color: var(--primary-med-or-secondary-med);
@@ -258,10 +257,13 @@
 
   .topic-actions {
     grid-area: actions;
-    float: right;
+    display: flex;
     justify-content: flex-end;
-    text-align: right;
-    vertical-align: bottom;
+
+    .inline {
+      align-self: center;
+      text-align: right;
+    }
   }
 
   .middot:after {

--- a/common/common.scss
+++ b/common/common.scss
@@ -15,7 +15,7 @@
     }
     display: grid;
     gap: 6px;
-    grid-template-columns: repeat(auto-fit, minmax(356px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(358px, 1fr));
     grid-auto-rows: 4px;
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -222,7 +222,6 @@
   .topic-users {
     grid-area: posters;
     display: flex;
-    justify-content: flex-end;
 
     .inline {
       align-self: center;

--- a/common/common.scss
+++ b/common/common.scss
@@ -318,6 +318,7 @@ img.thumbnail {
   font-size: 13px;
   display: inline-block;
   padding-right: 5px;
+  vertical-align: 0.125em;
 
   .vote-count {
     height: initial;

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -339,7 +339,6 @@ export default {
         @discourseComputed("likeCount")
         topicActions(likeCount) {
           let actions = [];
-          actions.push(this._shareButton());
           if (
             likeCount ||
             this.get("topic.topic_post_can_like") ||
@@ -348,6 +347,7 @@ export default {
           ) {
             actions.push(this._likeButton());
           }
+          actions.push(this._shareButton());
           if (this.get("canBookmark")) {
             actions.push(this._bookmarkButton());
             Ember.run.scheduleOnce("afterRender", this, () => {

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -252,14 +252,12 @@ export default {
         @discourseComputed
         abbreviatedPosters() {
           let abbreviatedPosters = [];
-          if (this.topic.posters.length < 5) {
+          if (this.topic.posters.length < 4) {
             abbreviatedPosters = this.topic.posters
           } else {
             this.topic.posters[0].count = false;
             abbreviatedPosters.push(this.topic.posters[0]);
-            this.topic.posters[1].count = false;
-            abbreviatedPosters.push(this.topic.posters[1]);
-            let count = {count: this.topic.posters.length - 3}
+            let count = {count: this.topic.posters.length - 2}
             abbreviatedPosters.push(count);
             this.topic.posters[this.topic.posters.length - 1].count = false;
             abbreviatedPosters.push(this.topic.posters[this.topic.posters.length - 1]);

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -480,6 +480,11 @@ export default {
               let bookmarkElement =
                 this.element.querySelector(".topic-bookmark");
               bookmarkElement.classList.toggle("bookmarked");
+              let title = "bookmarks.not_bookmarked";
+              if (this.topic.bookmarked) {
+                title = "bookmarks.created";
+              }
+              this.element.title = title;
             },
             500
           );

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -244,6 +244,29 @@ export default {
           return settings.topic_list_featured_images_tag.split("|");
         },
 
+        @discourseComputed
+        abbreviatePosters() {
+          return (this.topic.posters.length > 3);
+        },
+
+        @discourseComputed
+        abbreviatedPosters() {
+          let abbreviatedPosters = [];
+          if (this.topic.posters.length < 5) {
+            abbreviatedPosters = this.topic.posters
+          } else {
+            this.topic.posters[0].count = false;
+            abbreviatedPosters.push(this.topic.posters[0]);
+            this.topic.posters[1].count = false;
+            abbreviatedPosters.push(this.topic.posters[1]);
+            let count = {count: this.topic.posters.length - 3}
+            abbreviatedPosters.push(count);
+            this.topic.posters[this.topic.posters.length - 1].count = false;
+            abbreviatedPosters.push(this.topic.posters[this.topic.posters.length - 1]);
+          }
+          return abbreviatedPosters;
+        },
+
         _setupActions() {
           if (this._state === "destroying") return;
 

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -480,9 +480,9 @@ export default {
               let bookmarkElement =
                 this.element.querySelector(".topic-bookmark");
               bookmarkElement.classList.toggle("bookmarked");
-              let title = "bookmarks.not_bookmarked";
+              let title = I18n.t("bookmarks.not_bookmarked");
               if (this.topic.bookmarked) {
-                title = "bookmarks.remove";
+                title = I18n.t("bookmarks.remove");
               }
               bookmarkElement.title = title;
             },

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -484,7 +484,7 @@ export default {
               if (this.topic.bookmarked) {
                 title = "bookmarks.remove";
               }
-              this.element.title = title;
+              bookmarkElement.title = title;
             },
             500
           );

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -441,7 +441,9 @@ export default {
             title = "bookmarks.not_bookmarked";
           if (this.get("topic.topic_post_bookmarked")) {
             classes += " bookmarked";
-            title = "bookmarks.created";
+            title = I18n.t("bookmarks.created_generic", {
+              name: "",
+            })
           }
           return {
             type: "bookmark",
@@ -482,7 +484,9 @@ export default {
               bookmarkElement.classList.toggle("bookmarked");
               let title = "bookmarks.not_bookmarked";
               if (this.topic.bookmarked) {
-                title = "bookmarks.created";
+                title = I18n.t("bookmarks.created_generic", {
+                  name: "",
+                })
               }
               this.element.title = title;
             },

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -441,9 +441,7 @@ export default {
             title = "bookmarks.not_bookmarked";
           if (this.get("topic.topic_post_bookmarked")) {
             classes += " bookmarked";
-            title = I18n.t("bookmarks.created_generic", {
-              name: "",
-            })
+            title = "bookmarks.remove";
           }
           return {
             type: "bookmark",
@@ -484,9 +482,7 @@ export default {
               bookmarkElement.classList.toggle("bookmarked");
               let title = "bookmarks.not_bookmarked";
               if (this.topic.bookmarked) {
-                title = I18n.t("bookmarks.created_generic", {
-                  name: "",
-                })
+                title = "bookmarks.remove";
               }
               this.element.title = title;
             },

--- a/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-edits.js.es6
@@ -252,13 +252,17 @@ export default {
         @discourseComputed
         abbreviatedPosters() {
           let abbreviatedPosters = [];
-          if (this.topic.posters.length < 4) {
+          if (this.topic.posters.length < 6) {
             abbreviatedPosters = this.topic.posters
           } else {
             this.topic.posters[0].count = false;
             abbreviatedPosters.push(this.topic.posters[0]);
-            let count = {count: this.topic.posters.length - 2}
+            this.topic.posters[1].count = false;
+            abbreviatedPosters.push(this.topic.posters[1]);
+            let count = {count: this.topic.posters.length - 4}
             abbreviatedPosters.push(count);
+            this.topic.posters[this.topic.posters.length - 2].count = false;
+            abbreviatedPosters.push(this.topic.posters[this.topic.posters.length - 2]);
             this.topic.posters[this.topic.posters.length - 1].count = false;
             abbreviatedPosters.push(this.topic.posters[this.topic.posters.length - 1]);
           }

--- a/javascripts/discourse/lib/actions.js.es6
+++ b/javascripts/discourse/lib/actions.js.es6
@@ -1,5 +1,15 @@
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import showModal from "discourse/lib/show-modal";
+
+var shareTopic = function (topic) {
+  const controller = showModal("share-topic", {
+    model: topic.category,
+  });
+  controller.setProperties({
+    topic: topic,
+  });
+};
 
 var addLike = function (postId) {
   ajax("/post_actions", {
@@ -49,4 +59,4 @@ var removeLike = function (postId) {
   });
 };
 
-export { addLike, sendBookmark, removeLike };
+export { shareTopic, addLike, sendBookmark, removeLike };

--- a/javascripts/discourse/templates/list/topic-actions.hbr
+++ b/javascripts/discourse/templates/list/topic-actions.hbr
@@ -1,5 +1,7 @@
 <div class="topic-actions">
-  {{#each topicActions as |action|}}
-    {{list-button action}}
-  {{/each}}
+  <div class="inline">
+    {{#each topicActions as |action|}}
+      {{list-button action}}
+    {{/each}}
+  </div>
 </div>

--- a/javascripts/discourse/templates/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/list/topic-list-item.hbr
@@ -33,7 +33,7 @@
       {{/if}}
       <div class="topic-footer">
         {{raw 'list/topic-meta' likesHeat=likesHeat title=view.title topic=topic}}
-        {{raw "list/topic-users" tilesStyle=tilesStyle topic=topic posterNames=posterNames}}
+        {{raw "list/topic-users" tilesStyle=tilesStyle abbreviatePosters=abbreviatePosters posters=abbreviatedPosters posterNames=posterNames}}
         {{#if showActions}}
           {{raw "list/topic-actions" likeCount=likeCount topicActions=topicActions topic=topic}}
         {{/if}}

--- a/javascripts/discourse/templates/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/list/topic-list-item.hbr
@@ -21,6 +21,9 @@
           {{#if showCategoryBadge}}
             {{category-link topic.category}}
           {{/if}}
+          {{#if topic.tags}}
+            {{discourse-tags topic mode="list"}}
+          {{/if}}
         </div>
       </div>
       {{#if showExcerpt}}
@@ -28,10 +31,13 @@
           {{raw "list/topic-excerpt" topic=topic}}
         </a>
       {{/if}}
-      {{raw 'list/topic-meta' likesHeat=likesHeat title=view.title topic=topic}}
-      {{#if showActions}}
-        {{raw "list/topic-actions" likeCount=likeCount topicActions=topicActions topic=topic}}
-      {{/if}}
+      <div class="topic-footer">
+        {{raw 'list/topic-meta' likesHeat=likesHeat title=view.title topic=topic}}
+        {{raw "list/topic-users" tilesStyle=tilesStyle topic=topic posterNames=posterNames}}
+        {{#if showActions}}
+          {{raw "list/topic-actions" likeCount=likeCount topicActions=topicActions topic=topic}}
+        {{/if}}
+      </div>
     </div>
   </div>
 {{else}}

--- a/javascripts/discourse/templates/list/topic-list-title.hbr
+++ b/javascripts/discourse/templates/list/topic-list-title.hbr
@@ -43,5 +43,4 @@
   </span>
 {{#if tilesStyle}}
   </div>
-  {{raw "list/topic-users" tilesStyle=tilesStyle topic=topic posterNames=posterNames}}
 {{/if}}

--- a/javascripts/discourse/templates/list/topic-meta.hbr
+++ b/javascripts/discourse/templates/list/topic-meta.hbr
@@ -1,18 +1,20 @@
 <div class="topic-meta">
-  {{raw-plugin-outlet name="topic-list-tiles-meta"}}
-  <div class="topic-views {{topic.viewsHeat}} inline sub">
-    {{d-icon "far-eye"}}
-    {{number topic.views numberKey="views_long"}}
-  </div>
-  <span class="middot inline sub"></span>
-  <div class='topic-replies posts-map {{likesHeat}} inline sub' title='{{title}}'>
-    <a href class='posts-map badge-posts {{likesHeat}} aria-label="{{title}}"'>
-      {{d-icon "far-comment"}}
-      {{number topic.replyCount noTitle="true" ariaLabel=title}}
-    </a>
-  </div>
-  <span class="middot inline sub"></span>
-  <div class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity inline sub" title="{{{topic.bumpedAtTitle}}}">
-    <a href="{{topic.lastPostUrl}}">{{format-date topic.bumpedAt format="medium-with-ago" noTitle="true"}}</a>
+  <div class="inline">
+    {{raw-plugin-outlet name="topic-list-tiles-meta"}}
+    <div class="topic-views {{topic.viewsHeat}} inline sub">
+      {{d-icon "far-eye"}}
+      {{number topic.views numberKey="views_long"}}
+    </div>
+    <span class="middot inline sub"></span>
+    <div class='topic-replies posts-map {{likesHeat}} inline sub' title='{{title}}'>
+      <a href class='posts-map badge-posts {{likesHeat}} aria-label="{{title}}"'>
+        {{d-icon "far-comment"}}
+        {{number topic.replyCount noTitle="true" ariaLabel=title}}
+      </a>
+    </div>
+    <span class="middot inline sub"></span>
+    <div class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity inline sub" title="{{{topic.bumpedAtTitle}}}">
+      <a href="{{topic.lastPostUrl}}">{{format-date topic.bumpedAt format="medium-with-ago" noTitle="true"}}</a>
+    </div>
   </div>
 </div>

--- a/javascripts/discourse/templates/list/topic-meta.hbr
+++ b/javascripts/discourse/templates/list/topic-meta.hbr
@@ -1,8 +1,3 @@
-{{#if topic.tags}}
-  <div class="topic-tags">
-    {{discourse-tags topic mode="list"}}
-  </div>
-{{/if}}
 <div class="topic-meta">
   {{raw-plugin-outlet name="topic-list-tiles-meta"}}
   <div class="topic-views {{topic.viewsHeat}} inline sub">

--- a/javascripts/discourse/templates/list/topic-meta.hbr
+++ b/javascripts/discourse/templates/list/topic-meta.hbr
@@ -1,20 +1,26 @@
 <div class="topic-meta">
-  <div class="inline">
-    {{raw-plugin-outlet name="topic-list-tiles-meta"}}
-    <div class="topic-views {{topic.viewsHeat}} inline sub">
-      {{d-icon "far-eye"}}
-      {{number topic.views numberKey="views_long"}}
+  {{raw-plugin-outlet name="topic-list-tiles-meta"}}
+  <div class="container">
+    <div class="top-line">
+      <div class="topic-views {{topic.viewsHeat}} inline sub">
+        {{d-icon "far-eye"}}
+        {{number topic.views numberKey="views_long"}}
+      </div>
+      <div class='topic-replies posts-map {{likesHeat}} inline sub' title='{{title}}'>
+        <span class="middot inline sub"></span>
+        <a href class='posts-map badge-posts {{likesHeat}} aria-label="{{title}}"'>
+          {{d-icon "far-comment"}}
+          {{number topic.replyCount noTitle="true" ariaLabel=title}}
+        </a>
+      </div>
     </div>
-    <span class="middot inline sub"></span>
-    <div class='topic-replies posts-map {{likesHeat}} inline sub' title='{{title}}'>
-      <a href class='posts-map badge-posts {{likesHeat}} aria-label="{{title}}"'>
-        {{d-icon "far-comment"}}
-        {{number topic.replyCount noTitle="true" ariaLabel=title}}
-      </a>
-    </div>
-    <span class="middot inline sub"></span>
-    <div class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity inline sub" title="{{{topic.bumpedAtTitle}}}">
-      <a href="{{topic.lastPostUrl}}">{{format-date topic.bumpedAt format="medium-with-ago" noTitle="true"}}</a>
+    <div class="bottom-line">
+      <div class="topic-timing {{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity inline sub" title="{{{topic.bumpedAtTitle}}}">
+        <a href="{{topic.lastPostUrl}}">
+          {{d-icon "far-clock"}}
+          {{format-date topic.bumpedAt format="medium-with-ago" noTitle="true"}}
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/javascripts/discourse/templates/list/topic-meta.hbr
+++ b/javascripts/discourse/templates/list/topic-meta.hbr
@@ -6,7 +6,10 @@
   </div>
   <span class="middot inline sub"></span>
   <div class='topic-replies posts-map {{likesHeat}} inline sub' title='{{title}}'>
-    <a href class='posts-map badge-posts {{likesHeat}}'>{{d-icon "far-comment"}}{{number topic.replyCount}}</a>
+    <a href class='posts-map badge-posts {{likesHeat}} aria-label="{{title}}"'>
+      {{d-icon "far-comment"}}
+      {{number topic.replyCount noTitle="true" ariaLabel=title}}
+    </a>
   </div>
   <span class="middot inline sub"></span>
   <div class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity inline sub" title="{{{topic.bumpedAtTitle}}}">

--- a/javascripts/discourse/templates/list/topic-users.hbr
+++ b/javascripts/discourse/templates/list/topic-users.hbr
@@ -1,9 +1,13 @@
 <div class='topic-users'>
   <div class="inline">
-    {{#each topic.posters as |poster|}}
-      <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extras}}">
-        {{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" imageSize="small"}}
-      </a>
+    {{#each posters as |poster|}}
+     {{#unless poster.count}}
+       <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extras}}">
+         {{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" imageSize="small"}}
+       </a>
+      {{else}}
+        ({{poster.count}})
+      {{/unless}}
     {{/each}}
   </div>
 </div>

--- a/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
@@ -33,7 +33,7 @@
       {{/if}}
       <div class="topic-footer">
         {{raw 'list/topic-meta' likesHeat=likesHeat title=view.title topic=topic}}
-        {{raw "list/topic-users" tilesStyle=tilesStyle topic=topic posterNames=posterNames}}
+        {{raw "list/topic-users" tilesStyle=tilesStyle abbreviatePosters=abbreviatePosters posters=abbreviatedPosters posterNames=posterNames}}
         {{#if showActions}}
           {{raw "list/topic-actions" likeCount=likeCount topicActions=topicActions topic=topic}}
         {{/if}}

--- a/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
@@ -8,7 +8,7 @@
   <div class="tiles-grid-item-content main-link">
     <div class="image">
       {{#if hasThumbnail}}
-        {{raw "list/topic-thumbnail" topic=topic thumbnails=thumbnails category=category opts=thumbnailOpts}}
+        {{raw "list/topic-thumbnail" topic=topic thumbnails=thumbnails currentUser=currentUser site=site category=category opts=thumbnailOpts}}
       {{/if}}
       <a href='{{topic.url}}'>
         <div class="image-mask" style="{{backgroundGradient}}"></div>
@@ -21,6 +21,9 @@
           {{#if showCategoryBadge}}
             {{category-link topic.category}}
           {{/if}}
+          {{#if topic.tags}}
+            {{discourse-tags topic mode="list"}}
+          {{/if}}
         </div>
       </div>
       {{#if showExcerpt}}
@@ -28,10 +31,13 @@
           {{raw "list/topic-excerpt" topic=topic}}
         </a>
       {{/if}}
-      {{raw 'list/topic-meta' likesHeat=likesHeat title=view.title topic=topic}}
-      {{#if showActions}}
-        {{raw "list/topic-actions" likeCount=likeCount topicActions=topicActions topic=topic}}
-      {{/if}}
+      <div class="topic-footer">
+        {{raw 'list/topic-meta' likesHeat=likesHeat title=view.title topic=topic}}
+        {{raw "list/topic-users" tilesStyle=tilesStyle topic=topic posterNames=posterNames}}
+        {{#if showActions}}
+          {{raw "list/topic-actions" likeCount=likeCount topicActions=topicActions topic=topic}}
+        {{/if}}
+      </div>
     </div>
   </div>
 {{else}}

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -42,8 +42,6 @@
   }
 
   .like-count {
-    font-size: 1em;
-    line-height: 1em;
     float: left;
     margin-right: 8px;
   }
@@ -150,6 +148,12 @@
     display: block;
     padding-left: 0;
     padding-top: 3px;
+  }
+
+  .topic-actions {
+    .like-count {
+      float: unset;
+    }
   }
 }
 

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -108,24 +108,6 @@
     }
   }
 
-  .topic-users {
-    grid-area: posters;
-    padding: 0 0 5px 5px;
-
-    .inline {
-      float: right;
-      line-height: 24px;
-      text-align: right;
-
-      .avatar {
-        padding: 0 0 0 0px;
-        margin-right: -2px;
-        width: 22px;
-        height: 22px;
-      }
-    }
-  }
-
   .topic-statuses {
     float: right;
   }
@@ -150,10 +132,6 @@
     grid-area: tags;
   }
 
-  .topic-meta {
-    grid-area: meta;
-  }
-
   .topic-poster-names a {
     font-size: 0.9em;
   }
@@ -172,29 +150,6 @@
     display: block;
     padding-left: 0;
     padding-top: 3px;
-  }
-
-  .topic-meta {
-    float: left;
-  }
-
-  .topic-actions {
-    grid-area: actions;
-    float: right;
-    justify-content: flex-end;
-    text-align: right;
-    vertical-align: bottom;
-
-    .list-button {
-      font-size: 1em;
-      padding: 0 0 0 10px;
-      color: var(--primary-medium);
-
-      &.has-like,
-      &.topic-like:not([disabled]):hover {
-        color: var(--love);
-      }
-    }
   }
 }
 

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -30,7 +30,6 @@
   }
 
   .topic-actions {
-    margin-top: 5px;
     float: left;
     clear: both;
     display: flex;

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -43,7 +43,6 @@
 
   .like-count {
     float: left;
-    margin-right: 8px;
   }
 
   .list-button i {


### PR DESCRIPTION
* Rearrange items to make better use of space, specifically:
  * move posters to tile footer, ensure they just take up one line, add number representing number of additional posters if large list/
  * wrap meta to leave space for more posters
  * move tags alongside Category and continue to allow them to wrap
  * optimise padding
 * Add new share button ⛓️ so you can share a topic straight from the Topic List
 * Various fixes to action button behaviour and formatting
 * Reduction of redundancy in CSS (esp. between desktop and mobile).