### PR TITLE
COMPATIBILTY: update selector that caused non-tiles views to break 

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -331,7 +331,7 @@
   }
 }
 //styling excluding tiles
-html:not(>tile-style) {
+html:not(.tile-style) {
   .topic-list .link-bottom-line {
     display: block;
   }


### PR DESCRIPTION
due to incompatibility with Dart Sass 2.0.0