### PR TITLE
Only perform featured-topic-related class modifications when enabled

### DIFF
--- a/javascripts/discourse/initializers/preview-route-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-route-edits.js.es6
@@ -37,12 +37,12 @@ export default {
       ]);
     });
 
-    discoveryTopicRoutes.forEach(function(route){
-      var route = container.lookup(`route:discovery.${route}`);
-      route.reopen({
-        model(data, transition) {
-          return this._super(data, transition).then((result) => {
-            if (settings.topic_list_featured_images) {
+    if (settings.topic_list_featured_images) {
+      discoveryTopicRoutes.forEach(function(route){
+        var route = container.lookup(`route:discovery.${route}`);
+        route.reopen({
+          model(data, transition) {
+            return this._super(data, transition).then((result) => {
               let featuredTopics = null;
               let filter = `tag/${settings.topic_list_featured_images_tag}`;
               let lastTopicList = findOrResetCachedTopicList (this.session, filter);
@@ -52,106 +52,110 @@ export default {
                 });
                 this.controllerFor('discovery').set('featuredTopics', this.featuredTopics);
               });
-            }
-            return result;
-          })
-        }
-      });
-    });
 
-    discoveryCategoryRoutes.forEach(function(route){
-      var route = container.lookup(`route:discovery.${route}`);
-      route.reopen({
-        afterModel(model, transition) {
-          return this._super(model, transition).then((result) => {
-            if (settings.topic_list_featured_images_category) {
-              let featuredTopics = null;
-              let filter = `tag/${settings.topic_list_featured_images_tag}`;
-              let lastTopicList = findOrResetCachedTopicList (this.session, filter);
-              this.store.findFiltered ('topicList', {filter}).then (list => {
-                this.setProperties ({
-                  featuredTopics: Ember.Object.create (list),
-                });
-
-                this.controllerFor('discovery').set('featuredTopics', this.featuredTopics);
-              });
-            }
-            return result;
-          })
-        }
-      });
-    });
-
-    withPluginApi('0.8.12', api => {
-      api.modifyClass(`route:discovery-categories`, {
-        pluginId: PLUGIN_ID,
-
-        setFeaturedTopics() {
-          let sortOrder = settings.topic_list_featured_images_created_order ? "created" : "activity";
-
-          let filterObject = {
-            filter: "latest",
-            params: {
-              tags: [`${settings.topic_list_featured_images_tag}`],
-              order: sortOrder,
-            },
+              return result;
+            })
           }
-
-          this.store.findFiltered ("topicList", filterObject).then (list => {
-            this.setProperties ({
-              featuredTopics: EmberObject.create (list),
-            });
-
-            this.controllerFor('discovery').set('featuredTopics', this.featuredTopics);
-          })
-        },
-
-        // unfortunately we have to override this whole method to extract the featured topics
-        _findCategoriesAndTopics(filter) {
-          PreloadStore.reset();
-          return hash({
-            wrappedCategoriesList: PreloadStore.getAndRemove("categories_list"),
-            topicsList: PreloadStore.getAndRemove(`topic_list_${filter}`)
-          }).then((response) => {
-            let { wrappedCategoriesList, topicsList } = response;
-            let categoriesList =
-              wrappedCategoriesList && wrappedCategoriesList.category_list;
-
-            this.setFeaturedTopics();
-
-            if (categoriesList && topicsList) {
-              if (topicsList.topic_list && topicsList.topic_list.top_tags) {
-                Site.currentProp("top_tags", topicsList.topic_list.top_tags);
-              }
-
-              return EmberObject.create({
-                categories: CategoryList.categoriesFrom(
-                  this.store,
-                  wrappedCategoriesList
-                ),
-                topics: TopicList.topicsFrom(this.store, topicsList),
-                can_create_category: categoriesList.can_create_category,
-                can_create_topic: categoriesList.can_create_topic,
-                loadBefore: this._loadBefore(store),
-              });
-            }
-            // Otherwise, return the ajax result
-            return ajax(`/categories_and_${filter}`).then(result => {
-              if (result.topic_list && result.topic_list.top_tags) {
-                Site.currentProp("top_tags", result.topic_list.top_tags);
-              }
-
-              return EmberObject.create({
-                categories: CategoryList.categoriesFrom(this.store, result),
-                topics: TopicList.topicsFrom(this.store, result),
-                can_create_category: result.category_list.can_create_category,
-                can_create_topic: result.category_list.can_create_topic,
-                loadBefore: this._loadBefore(this.store),
-              });
-            });
-          });
-        }
+        });
       });
-    });
+    }
+    
+    if (settings.topic_list_featured_images_category) {
+      discoveryCategoryRoutes.forEach(function(route){
+        var route = container.lookup(`route:discovery.${route}`);
+        route.reopen({
+          afterModel(model, transition) {
+            return this._super(model, transition).then((result) => {
+              let featuredTopics = null;
+              let filter = `tag/${settings.topic_list_featured_images_tag}`;
+              let lastTopicList = findOrResetCachedTopicList (this.session, filter);
+              this.store.findFiltered ('topicList', {filter}).then (list => {
+                this.setProperties ({
+                  featuredTopics: Ember.Object.create (list),
+                });
+
+                this.controllerFor('discovery').set('featuredTopics', this.featuredTopics);
+              });
+
+              return result;
+            })
+          }
+        });
+      });
+    }
+
+    if(settings.topic_list_featured_images_tag){
+      withPluginApi('0.8.12', api => {
+        api.modifyClass(`route:discovery-categories`, {
+          pluginId: PLUGIN_ID,
+
+          setFeaturedTopics() {
+            let sortOrder = settings.topic_list_featured_images_created_order ? "created" : "activity";
+
+            let filterObject = {
+              filter: "latest",
+              params: {
+                tags: [`${settings.topic_list_featured_images_tag}`],
+                order: sortOrder,
+              },
+            }
+
+            this.store.findFiltered ("topicList", filterObject).then (list => {
+              this.setProperties ({
+                featuredTopics: EmberObject.create (list),
+              });
+
+              this.controllerFor('discovery').set('featuredTopics', this.featuredTopics);
+            })
+          },
+
+          // unfortunately we have to override this whole method to extract the featured topics
+          _findCategoriesAndTopics(filter) {
+            PreloadStore.reset();
+            return hash({
+              wrappedCategoriesList: PreloadStore.getAndRemove("categories_list"),
+              topicsList: PreloadStore.getAndRemove(`topic_list_${filter}`)
+            }).then((response) => {
+              let { wrappedCategoriesList, topicsList } = response;
+              let categoriesList =
+                wrappedCategoriesList && wrappedCategoriesList.category_list;
+
+              this.setFeaturedTopics();
+
+              if (categoriesList && topicsList) {
+                if (topicsList.topic_list && topicsList.topic_list.top_tags) {
+                  Site.currentProp("top_tags", topicsList.topic_list.top_tags);
+                }
+
+                return EmberObject.create({
+                  categories: CategoryList.categoriesFrom(
+                    this.store,
+                    wrappedCategoriesList
+                  ),
+                  topics: TopicList.topicsFrom(this.store, topicsList),
+                  can_create_category: categoriesList.can_create_category,
+                  can_create_topic: categoriesList.can_create_topic,
+                  loadBefore: this._loadBefore(store),
+                });
+              }
+              // Otherwise, return the ajax result
+              return ajax(`/categories_and_${filter}`).then(result => {
+                if (result.topic_list && result.topic_list.top_tags) {
+                  Site.currentProp("top_tags", result.topic_list.top_tags);
+                }
+
+                return EmberObject.create({
+                  categories: CategoryList.categoriesFrom(this.store, result),
+                  topics: TopicList.topicsFrom(this.store, result),
+                  can_create_category: result.category_list.can_create_category,
+                  can_create_topic: result.category_list.can_create_topic,
+                  loadBefore: this._loadBefore(this.store),
+                });
+              });
+            });
+          }
+        });
+      });
+    }
   }
 };


### PR DESCRIPTION
These modifications are intricate and highly-coupled to core internals, so they are very likely to need updating over time as core changes. To reduce risk for the majority of users, we can move the conditionals outside the class modifications so that they only apply to people with the relevant settings enabled.

(this diff is mostly indentation changes, and will be easier to review [using ?w=1](https://github.com/paviliondev/discourse-tc-topic-list-previews/pull/30/files?w=1))