### PR TITLE
DEV: Resolve `link-to.positional-arguments` deprecation

### DIFF
--- a/javascripts/discourse/connectors/user-activity-bottom/portfolio-list.hbs
+++ b/javascripts/discourse/connectors/user-activity-bottom/portfolio-list.hbs
@@ -1,5 +1,5 @@
 {{#if portfolioEnabled}}
-  {{#link-to "userActivity.portfolio"}}
+  {{#link-to route="userActivity.portfolio"}}
     {{d-icon "images"}} {{theme-i18n "tlp.user_activity_portfolio_title"}}
   {{/link-to}}
 {{/if}}


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments

This deprecation happens at build-time, which means it doesn't get surfaced like other deprecations in Discourse themes/plugins.